### PR TITLE
Refactor trigger variable declarations

### DIFF
--- a/model.sql
+++ b/model.sql
@@ -283,6 +283,7 @@ FOR EACH ROW
 BEGIN
   DECLARE v_area INT;
   DECLARE v_req_carrera TINYINT;
+  DECLARE v_carr_area INT;
   SELECT id_area, requiere_carrera INTO v_area, v_req_carrera
   FROM indicador WHERE id_indicador = NEW.id_indicador;
 
@@ -300,7 +301,6 @@ BEGIN
 
   -- Si hay carrera, debe pertenecer a SUAYED (id_area=1 por seed; o mejor validamos por la carrera misma)
   IF NEW.id_carrera IS NOT NULL THEN
-    DECLARE v_carr_area INT;
     SELECT id_area INTO v_carr_area FROM carrera WHERE id_carrera = NEW.id_carrera;
     IF v_carr_area <> v_area THEN
       SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'La carrera no pertenece al área del indicador.';
@@ -314,6 +314,7 @@ FOR EACH ROW
 BEGIN
   DECLARE v_area INT;
   DECLARE v_req_carrera TINYINT;
+  DECLARE v_carr_area INT;
   SELECT id_area, requiere_carrera INTO v_area, v_req_carrera
   FROM indicador WHERE id_indicador = NEW.id_indicador;
 
@@ -328,7 +329,6 @@ BEGIN
   END IF;
 
   IF NEW.id_carrera IS NOT NULL THEN
-    DECLARE v_carr_area INT;
     SELECT id_area INTO v_carr_area FROM carrera WHERE id_carrera = NEW.id_carrera;
     IF v_carr_area <> v_area THEN
       SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'La carrera no pertenece al área del indicador.';


### PR DESCRIPTION
## Summary
- Declare `v_carr_area` at the top of `trg_valor_indicador_bi` and `trg_valor_indicador_bu` triggers for clarity

## Testing
- `mariadb --socket=/tmp/mysql.sock < model.sql` *(fails: Truncated incorrect DOUBLE value: 'Jefatura ')*
- `mariadb --socket=/tmp/mysql.sock -e "SHOW TRIGGERS FROM duacyd_analitica LIKE 'valor_indicador'\G"`


------
https://chatgpt.com/codex/tasks/task_e_689d71762f908322a3b83314bbc8c667