### PR TITLE
Fix vertical layout of menu body

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -489,6 +489,8 @@ body::before {
   min-height:100vh;
   position:relative;
   overflow-x:hidden;
+  display:flex;
+  flex-direction:column;
 }
 
 .menu-body::before{


### PR DESCRIPTION
## Summary
- Restore flex column layout for `.menu-body` to ensure navbar spans full width at top

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689d84376d5083229ce09ce3bddf6e6d